### PR TITLE
Remove AWS_ACCOUNT_ID from serverless environment

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -17,7 +17,6 @@ provider:
         - 'secretsmanager:GetSecretValue'
       Resource: 'arn:aws:secretsmanager:${self:provider.region}:${self:provider.environment.AWS_ACCOUNT_ID}:*'
   environment:
-    AWS_ACCOUNT_ID: ${env:AWS_ACCOUNT_ID}
     BAMBOOHR_SUBDOMAIN: ${env:BAMBOOHR_SUBDOMAIN}
     EMPLOYEE_COUNTRY_FILTER: ${env:EMPLOYEE_COUNTRY_FILTER}
     CELEBRATIONS_WEBHOOK_URL: ${env:CELEBRATIONS_WEBHOOK_URL}


### PR DESCRIPTION
### Main changes

- fix: remove AWS_ACCOUNT_ID from serverless environment