### PR TITLE
feat(#11): add default message for days without birthdays

### DIFF
--- a/src/constants/defaultMessage.ts
+++ b/src/constants/defaultMessage.ts
@@ -1,0 +1,10 @@
+export default {
+  type: 'context',
+  elements: [
+    {
+      type: 'mrkdwn',
+      plain_text:
+        ':mad-hatter::teapot: *A very Merry Unbirthday to you all!* :mad-hatter::teapot:',
+    },
+  ],
+};

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -264,11 +264,21 @@ export const publishEmployeesCelebrations = async (
         ],
       }))
     );
-
+  } else {
     birthdaysBlocks.push({
-      type: 'divider',
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          plain_text:
+            ':mad-hatter::teapot: *A very Merry Unbirthday to you all!* :mad-hatter::teapot:',
+        },
+      ],
     });
   }
+  birthdaysBlocks.push({
+    type: 'divider',
+  });
 
   // ANNIVERSARY
   const anniversaries = employees

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -1,5 +1,7 @@
 import moment from 'moment';
 
+import defaultMessage from './constants/defaultMessage';
+
 import {
   TBambooHREmployeeAtOffice,
   TBambooHREmployeeExtended,
@@ -264,21 +266,10 @@ export const publishEmployeesCelebrations = async (
         ],
       }))
     );
-  } else {
     birthdaysBlocks.push({
-      type: 'context',
-      elements: [
-        {
-          type: 'mrkdwn',
-          plain_text:
-            ':mad-hatter::teapot: *A very Merry Unbirthday to you all!* :mad-hatter::teapot:',
-        },
-      ],
+      type: 'divider',
     });
   }
-  birthdaysBlocks.push({
-    type: 'divider',
-  });
 
   // ANNIVERSARY
   const anniversaries = employees
@@ -368,22 +359,43 @@ export const publishEmployeesCelebrations = async (
     });
   }
 
-  const message = {
-    text: "🥳 Let's celebrate together",
-    blocks: [
-      {
-        type: 'header',
-        text: {
-          type: 'plain_text',
-          text: "🥳 Let's celebrate together",
-          emoji: true,
+  const celebrationMessages = [
+    ...firstDayBlocks,
+    ...birthdaysBlocks,
+    ...anniversariesBlocks,
+  ];
+
+  const buildMessageToSend = (messages: object[]) => {
+    const base = {
+      text: "🥳 Let's celebrate together",
+      blocks: [
+        {
+          type: 'header',
+          text: {
+            type: 'plain_text',
+            text: "🥳 Let's celebrate together",
+            emoji: true,
+          },
         },
-      },
-      ...firstDayBlocks,
-      ...birthdaysBlocks,
-      ...anniversariesBlocks,
-    ],
+      ],
+    };
+
+    return messages.length > 0
+      ? {
+          ...base,
+          blocks: [...base.blocks, ...messages],
+        }
+      : {
+          ...base,
+          blocks: {
+            ...base.blocks,
+            defaultMessage,
+          },
+        };
   };
 
-  await postSlackMessage(process.env.CELEBRATIONS_WEBHOOK_URL ?? '', message);
+  await postSlackMessage(
+    process.env.CELEBRATIONS_WEBHOOK_URL ?? '',
+    buildMessageToSend(celebrationMessages)
+  );
 };


### PR DESCRIPTION
This PR fixes #11. 

# Main changes

This PR creates a default message for when it is nobody's birthday, so there is always something to celebrate. 

# Notes

Message appearance has been tested using [Slack Block Kit Builder](https://app.slack.com/block-kit-builder/T2G4ZDZTK#%7B%22blocks%22:%5B%7B%22type%22:%22header%22,%22text%22:%7B%22type%22:%22plain_text%22,%22text%22:%22%F0%9F%A5%B3%20Let's%20celebrate%20together%22,%22emoji%22:true%7D%7D,%7B%22type%22:%22context%22,%22elements%22:%5B%7B%22type%22:%22mrkdwn%22,%22text%22:%22:mad-hatter::teapot:*A%20very%20Merry%20Unbirthday%20to%20you%20all!*:mad-hatter::teapot:%22%7D%5D%7D,%7B%22type%22:%22divider%22%7D%5D%7D).